### PR TITLE
Easy Test GSOC25 : bug fixes for passing CRAN checks

### DIFF
--- a/R/rotation.R
+++ b/R/rotation.R
@@ -29,7 +29,7 @@ profileRotation <- function(d, indexList, indexLabels, n=200){
     dprj <- d %*% rotM
     res <- c()
     for (idx in indexList){
-      res <- c(res, idx(dprj))
+      res <- c(res, as.numeric(idx(dprj)))
     }
     resMat[i,] <- c(res, a)
     i <- i+1

--- a/R/smoothing.R
+++ b/R/smoothing.R
@@ -44,7 +44,8 @@ getIndexMean <- function(proj, d, alpha, idx, method="jitterAngle", n=10){
     valVec <- replicate(n, jitterPoints(dProj, alpha, idx))
   }
   else { return(orig)}
-  return(mean(c(orig, valVec)))
+  return(as.numeric(mean(c(orig, valVec))))
+
 }
 
 #' Compare traces with different smoothing options.
@@ -73,7 +74,7 @@ compareSmoothing <- function(d, tPath, idx, alphaV=c(0.01, 0.05, 0.1), n=10){
   for (method in c("jitterAngle", "jitterPoints", "noSmoothing")){
     for (alpha in alphaV){
       for (i in seq_along(tPath)) {
-        idM <- getIndexMean(tPath[[i]], d, alpha, idx, method, n)
+        idM <- as.numeric(getIndexMean(tPath[[i]], d, alpha, idx, method, n))
         sc <- sc %>%
           tibble::add_row(indexMean=idM, t=i, method=method, alpha=alpha)
       }

--- a/R/timer.R
+++ b/R/timer.R
@@ -11,25 +11,42 @@
 #' @return numeric vector containing all distances
 #' @export
 #' @examples \donttest{
+#' library(purrr)  # Ensure purrr is loaded
 #' d <- spiralData(4, 1000)
-#' t <- purrr::rerun(10, tourr::basis_random(4))
+#' t <- map(1:10, tourr::basis_random(4))
 #' idx <- scagIndex("Skinny")
 #' timeSequence(d, t, idx, 10)
 #' }
 timeSequence <- function(d, t, idx, pmax){
   i <- 1
   dfTimer <- data.frame(t= numeric(), i=numeric())
+  if (is.null(d) || !is.numeric(as.matrix(d))) {
+    stop("Error: 'd' must be a numeric matrix.")
+  }
+  d <- as.matrix(d)
   for(pMatrix in t){
     if(i>pmax) break
+    if (is.null(pMatrix) || !is.numeric(as.matrix(pMatrix))) {
+      warning("Skipping iteration: 'pMatrix' is NULL or not numeric.")
+      next
+    }
+    pMatrix <- as.matrix(pMatrix)
     tictoc::tic.clearlog()
     tictoc::tic() #start timer
     dProj <- d %*% pMatrix
     res <- idx(dProj)
     tictoc::toc(log=TRUE,quiet=TRUE)
-    resT <- unlist(tictoc::tic.log(format=FALSE))["toc.elapsed"] -
-      unlist(tictoc::tic.log(format=FALSE))["tic.elapsed"]
+    log_values <- tictoc::tic.log(format = FALSE)
+    
+    if (length(log_values) > 0 && is.list(log_values[[1]])) {
+      resT <- log_values[[1]]$toc - log_values[[1]]$tic
+    } else {
+      resT <- NA  # Assign NA if no valid timing data
+      warning("tic.log() did not return expected values.")
+    }
+    
     dfTimer <- tibble::add_row(dfTimer, t=resT, i=i)
-    i <- i+1
+    i <- i + 1
   }
   return(dfTimer)
 }

--- a/man/timeSequence.Rd
+++ b/man/timeSequence.Rd
@@ -25,8 +25,9 @@ get an overview of the distribution of computing times.
 }
 \examples{
 \donttest{
+library(purrr)  # Ensure purrr is loaded
 d <- spiralData(4, 1000)
-t <- purrr::rerun(10, tourr::basis_random(4))
+t <- map(1:10, tourr::basis_random(4))
 idx <- scagIndex("Skinny")
 timeSequence(d, t, idx, 10)
 }


### PR DESCRIPTION
In smoothing.R script the indexMean is sometimes a double and sometimes a data.frame inside compareSmoothing().
-  Modified the return statement in getIndexMean() and ensured that idM is Always Numeric in compareSmoothing()

In rotation.R script there was an error due to res being a data frame instead of a numeric vector, incorrect number of subscripts on matrix
- Ensured idx(dprj) returns a Numeric Value

In timer.R tic.log() returned non-numeric values, causing a subtraction error. 
- Ensured tic.log(format=FALSE) outputs numeric values before computation.



